### PR TITLE
Force HTTPS & TLS 1.2 when installing Rust

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -16,6 +16,10 @@ FROM base as rust
 # Install build tools
 RUN apt-get -q update && apt-get install -yq --no-install-recommends build-essential curl file
 
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=923479
+# https://github.com/balena-io-library/base-images/issues/562
+RUN c_rehash
+
 ENV PATH=/root/.cargo/bin:$PATH
 
 # Install Rust

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -19,7 +19,7 @@ RUN apt-get -q update && apt-get install -yq --no-install-recommends build-essen
 ENV PATH=/root/.cargo/bin:$PATH
 
 # Install Rust
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 ################################################################################
 # Dependencies


### PR DESCRIPTION
* Copy & paste from the rustup.rs site
* Rehash certificates before curl usage
  * See https://github.com/balena-io-library/base-images/issues/562 & https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=923479

Change-type: patch
Signed-off-by: Robert Vojta <robert@balena.io>