### PR TITLE
use wget instead of curl

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -14,7 +14,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 FROM base as rust
 
 # Install build tools
-RUN apt-get -q update && apt-get install -yq --no-install-recommends build-essential curl file
+RUN apt-get -q update && apt-get install -yq --no-install-recommends build-essential wget file && apt-get remove curl
 
 ENV PATH=/root/.cargo/bin:$PATH
 
@@ -30,7 +30,7 @@ RUN ./modify-uname.sh %%RESIN_ARCH%%
 
 # Install rustup downloading the version specified by the standard rust-toolchain file
 COPY rust-toolchain .
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain `cat rust-toolchain`
+RUN wget --no-verbose --secure-protocol=TLSv1_2 -qO- https://sh.rustup.rs | sh -s -- -y --default-toolchain `cat rust-toolchain`
 
 ################################################################################
 # Dependencies


### PR DESCRIPTION
Closes #23 

Hilariously, the rustup script finds curl and attempts to use it again, so it has to be explicitly removed or renamed or something

This fix worksin my project, but when I test it in this repo I get 
```
[main]     Step 11/29 : RUN wget --no-verbose --secure-protocol=TLSv1_2 -qO- https://sh.rustup.rs | sh -s -- -y --default-toolchain `cat rust-toolchain`
[main]      ---> Running in d9329fdd93da
[main]     Aborted (core dumped)
```

So not sure yet whats different..