### PR TITLE
Remove INITSYSTEM=on

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,7 +4,6 @@
 
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian as base
 
-ENV INITSYSTEM=on
 ENV DEBIAN_FRONTEND=noninteractive
 
 ################################################################################


### PR DESCRIPTION
It’s no longer supported.

Change-type: patch
Signed-off-by: Robert Vojta <robert@balena.io>