### PR TITLE
Pin compiler version to 1.37.0

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -22,7 +22,7 @@ RUN c_rehash
 ENV PATH=/root/.cargo/bin:$PATH
 
 # Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.37.0 -y
 
 ################################################################################
 # Dependencies


### PR DESCRIPTION
Rust 1.38.0 [1] segfaults during compilation on ARMv7. Until this is
fixed in a new compiler release, pin the compiler version.

[1] https://github.com/rust-lang/rust/issues/62896

Change-type: patch
Signed-off-by: Zahari Petkov <zahari@balena.io>