### PR TITLE
Update rust docker tag to v1.86

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,5 +1,5 @@
 # Rust as the base image
-FROM rust:1.65-slim as builder
+FROM rust:1.86-slim as builder
 
 # 1. Create a new empty shell project
 RUN USER=root cargo new --bin balena-rust-hello-world


### PR DESCRIPTION
Update Rust base image from v1.65 to v1.86 to fix Cargo 2024 edition error

Change-type: patch